### PR TITLE
underscore removed from assets folder

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,7 @@ var webpack = require('webpack');
 module.exports = {
   entry: './webpack/entry.js',
   output: {
-    path: 'src/_assets/javascript/',
+    path: 'src/assets/javascript/',
     filename: 'bundle.js'
   },
   module: {


### PR DESCRIPTION
...because Jekyll wasn't picking up the `_assets` folder